### PR TITLE
Fix Typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This repository contains a student project created for an ongoing lecture on object-oriented programming with Java at HWR Berlin (summer term 2022).
 
-> :warning: This code is for educational purpose only. Do not rely on it!
+> :warning: This code is for educational purposes only. Do not rely on it!
 
 ## Abstract
 


### PR DESCRIPTION
Change "purpose" in first warning to "purposes". 
In this context, the plural spelling is always used.