### PR TITLE
fix: NoClassDefFoundError | Alternative Solution

### DIFF
--- a/cli
+++ b/cli
@@ -1,6 +1,9 @@
 #!/bin/bash
 
+KOTLIN_LIBS=$(find ~/.m2/repository/org/jetbrains/kotlin/ -name "*.jar" | tr '\n' ':')
+
 # TODO Rename your .jar-File according to your project's name and version in pom.xml
 # TODO Rename this `cli` file to your project's domain, i. e. 'chess', 'skat', 'doppelkopf', or 'library'
 # TODO Instead of Example#main, start your own application entry point
-java -cp target/TODO_ENTER_YOUR_PROJECT_NAME_HERE-0.1.0.jar hwr.oop.Example $@
+
+java -cp "target/TODO_ENTER_YOUR_PROJECT_NAME_HERE-0.1.0.jar:$KOTLIN_LIBS" hwr.oop.Example $@

--- a/cli
+++ b/cli
@@ -1,9 +1,7 @@
 #!/bin/bash
 
-KOTLIN_LIBS=$(find ~/.m2/repository/org/jetbrains/kotlin/ -name "*.jar" | tr '\n' ':')
-
 # TODO Rename your .jar-File according to your project's name and version in pom.xml
 # TODO Rename this `cli` file to your project's domain, i. e. 'chess', 'skat', 'doppelkopf', or 'library'
 # TODO Instead of Example#main, start your own application entry point
 
-java -cp "target/TODO_ENTER_YOUR_PROJECT_NAME_HERE-0.1.0.jar:$KOTLIN_LIBS" hwr.oop.Example $@
+kotlin -cp target/TODO_ENTER_YOUR_PROJECT_NAME_HERE-0.1.0.jar hwr.oop.Example

--- a/src/main/kotlin/hwr/oop/KotlinExample.kt
+++ b/src/main/kotlin/hwr/oop/KotlinExample.kt
@@ -5,3 +5,13 @@ class KotlinExample {
     return "Hello World!"
   }
 }
+
+class Example {
+  companion object {
+    @JvmStatic
+    fun main(args: Array<String>) {
+      val example = KotlinExample()
+      println(example.sayHello())
+    }
+  }
+}

--- a/src/main/kotlin/hwr/oop/KotlinExample.kt
+++ b/src/main/kotlin/hwr/oop/KotlinExample.kt
@@ -6,12 +6,10 @@ class KotlinExample {
   }
 }
 
-class Example {
-  companion object {
+object Example {
     @JvmStatic
     fun main(args: Array<String>) {
       val example = KotlinExample()
       println(example.sayHello())
     }
-  }
 }


### PR DESCRIPTION
## 🐞 Problem

Running the application via the CLI resulted in the following runtime exception:

```
Exception in thread "main" java.lang.NoClassDefFoundError: kotlin/jvm/internal/Intrinsics
    at hwr.oop.Example$Companion.main(KotlinExample.kt)
    ...
Caused by: java.lang.ClassNotFoundException: kotlin.jvm.internal.Intrinsics
```

This indicates that the Kotlin standard library was not included on the runtime classpath.

## 🔍 Root Cause

The Kotlin compiler generates bytecode that depends on the Kotlin standard library (e.g., `Intrinsics`, `CollectionsKt`, etc.). If these classes aren't present during runtime, the application will fail to start.

## ✅ Solution

- Replaced the `java -cp` command with `kotlin` command for including kotlin deps.

## 📁 Files Changed / Added

- `cli` – Bash script that runs the application with the correct classpath.
- `KotlinExample.kt` – Contains `Example()` entry-object (singleton) for `kotlin` execution.

## ⚠️ Disclaimer

- This is one possible approach to resolve the issue, but not the only solution.
- Using this approach, one needs to have `kotlin` runtime installed.
- See another approach being used in this PR (#66).
