### PR TITLE
chore: remove dependency from java standard library main test

### DIFF
--- a/src/test/kotlin/hwr/oop/MainTest.kt
+++ b/src/test/kotlin/hwr/oop/MainTest.kt
@@ -1,25 +1,17 @@
 package hwr.oop
 
 import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.extensions.system.captureStandardOut
 import org.assertj.core.api.Assertions.assertThat
-import java.io.ByteArrayOutputStream
-import java.io.PrintStream
 
 class MainTest : AnnotationSpec() {
+
   @Test
   fun `main prints hello world to stdout`() {
-    val outputStream = ByteArrayOutputStream()
-    val printStream = PrintStream(outputStream)
-    val originalOut = System.out
-
-    try {
-      System.setOut(printStream)
+    val output = captureStandardOut {
       main()
-      System.out.flush()
-      val output = outputStream.toString().trim()
-      assertThat(output).isEqualTo("Hello World!")
-    } finally {
-      System.setOut(originalOut)
-    }
+    }.trim()
+    assertThat(output).isEqualTo("Hello World!")
   }
+
 }


### PR DESCRIPTION
Hi @dev-laky, I also just discovered, that Kotest has a nice support for testing stdout (also without using the java standard library) which was not used in #68. Because Kotest is a Kotlin Native project, we have no JVM-specific code now! 🙂 